### PR TITLE
Adicionados os filtros dinâmicos em Customers e Adresses

### DIFF
--- a/src/main/java/com/higor/poc1/api/controller/AddressController.java
+++ b/src/main/java/com/higor/poc1/api/controller/AddressController.java
@@ -5,10 +5,13 @@ import com.higor.poc1.domain.model.Address;
 import com.higor.poc1.domain.model.Customer;
 import com.higor.poc1.domain.repository.AddressRepository;
 import com.higor.poc1.domain.service.AddressService;
-import com.higor.poc1.domain.service.CustomerService;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.ReflectionUtils;
@@ -31,8 +34,11 @@ public class AddressController {
     private AddressService addressService;
 
     @GetMapping
-    public ResponseEntity<List<Address>> getAddress() {
-        return ResponseEntity.ok(addressRepository.findAll());
+    public ResponseEntity<Page<Address>> getAddress(
+            @PageableDefault(sort = "id",
+                    direction = Sort.Direction.ASC, page = 0, size = 10)
+                    Pageable paginacao) {
+        return ResponseEntity.ok(addressRepository.findAll(paginacao));
     }
 
     @GetMapping("/{addressId}")
@@ -126,5 +132,10 @@ public class AddressController {
 
             ReflectionUtils.setField(field, addressToPatch, newValue);
         });
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Address>> searchAddress(String street, String number, String district, String zipCode, String state){
+        return ResponseEntity.ok(addressRepository.find(street, number, district, zipCode, state));
     }
 }

--- a/src/main/java/com/higor/poc1/api/controller/CustomerController.java
+++ b/src/main/java/com/higor/poc1/api/controller/CustomerController.java
@@ -7,6 +7,10 @@ import com.higor.poc1.domain.service.CustomerService;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.ReflectionUtils;
@@ -29,8 +33,11 @@ public class CustomerController {
     private CustomerRepository customerRepository;
 
     @GetMapping
-    public ResponseEntity<List<Customer>> getCustomer() {
-        List<Customer> customers = customerRepository.findAll();
+    public ResponseEntity<Page<Customer>> getCustomer(
+            @PageableDefault(sort = "id",
+                    direction = Sort.Direction.ASC, page = 0, size = 10)
+                    Pageable paginacao) {
+        Page<Customer> customers = customerRepository.findAll(paginacao);
 
         return ResponseEntity.ok(customers);
     }
@@ -117,5 +124,10 @@ public class CustomerController {
 
             ReflectionUtils.setField(field, customerToPatch, newValue);
         });
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Customer>> searchCustomer(String name, String email, String registerNumber, String type, String phoneNumber){
+        return ResponseEntity.ok(customerRepository.find(name, email, registerNumber, type, phoneNumber));
     }
 }

--- a/src/main/java/com/higor/poc1/domain/repository/AddressRepository.java
+++ b/src/main/java/com/higor/poc1/domain/repository/AddressRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AddressRepository extends JpaRepository<Address, Long> {
+public interface AddressRepository extends JpaRepository<Address, Long>, AddressRepositoryQueries {
 }

--- a/src/main/java/com/higor/poc1/domain/repository/AddressRepositoryQueries.java
+++ b/src/main/java/com/higor/poc1/domain/repository/AddressRepositoryQueries.java
@@ -1,0 +1,10 @@
+package com.higor.poc1.domain.repository;
+
+import com.higor.poc1.domain.model.Address;
+
+import java.util.List;
+
+public interface AddressRepositoryQueries {
+
+    List<Address> find(String street, String number, String district, String zipCode, String state);
+}

--- a/src/main/java/com/higor/poc1/domain/repository/CustomerRepository.java
+++ b/src/main/java/com/higor/poc1/domain/repository/CustomerRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CustomerRepository extends JpaRepository<Customer, Long> {
+public interface CustomerRepository extends JpaRepository<Customer, Long>, CustomerRepositoryQueries {
 }

--- a/src/main/java/com/higor/poc1/domain/repository/CustomerRepositoryQueries.java
+++ b/src/main/java/com/higor/poc1/domain/repository/CustomerRepositoryQueries.java
@@ -1,0 +1,10 @@
+package com.higor.poc1.domain.repository;
+
+import com.higor.poc1.domain.model.Customer;
+
+import java.util.List;
+
+public interface CustomerRepositoryQueries {
+
+    List<Customer> find(String name, String email, String registerNumber, String type, String phoneNumber);
+}

--- a/src/main/java/com/higor/poc1/infrastructure/repository/AddressRepositoryImpl.java
+++ b/src/main/java/com/higor/poc1/infrastructure/repository/AddressRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.higor.poc1.infrastructure.repository;
+
+import com.higor.poc1.domain.model.Address;
+import com.higor.poc1.domain.repository.AddressRepositoryQueries;
+import com.higor.poc1.domain.repository.AddressRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class AddressRepositoryImpl implements AddressRepositoryQueries {
+
+    @PersistenceContext
+    private EntityManager manager;
+
+    @Autowired @Lazy
+    public AddressRepository addressRepository;
+
+    @Override
+    public List<Address> find(String street, String number, String district, String zipCode, String state) {
+        CriteriaBuilder builder = manager.getCriteriaBuilder();
+
+        CriteriaQuery<Address> criteria = builder.createQuery(Address.class);
+        Root<Address> root = criteria.from(Address.class);
+
+        var predicates = new ArrayList<Predicate>();
+
+        if (StringUtils.hasText(street)){
+            predicates.add(builder.like(root.get("street"), "%" + street + "%"));
+        }
+
+        if (StringUtils.hasText(number)){
+            predicates.add(builder.like(root.get("number"), "%" + number + "%"));
+        }
+
+        if (StringUtils.hasText(district)){
+            predicates.add(builder.like(root.get("district"), "%" + district + "%"));
+        }
+
+        if (StringUtils.hasText(zipCode)){
+            predicates.add(builder.like(root.get("zipCode"), "%" + zipCode + "%"));
+        }
+
+        if (StringUtils.hasText(state)){
+            predicates.add(builder.like(root.get("state"), "%" + state + "%"));
+        }
+
+        criteria.where(predicates.toArray(new Predicate[0]));
+
+        TypedQuery<Address> query = manager.createQuery(criteria);
+
+        return query.getResultList();
+    }
+}

--- a/src/main/java/com/higor/poc1/infrastructure/repository/CustomerRepositoryImpl.java
+++ b/src/main/java/com/higor/poc1/infrastructure/repository/CustomerRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.higor.poc1.infrastructure.repository;
+
+import com.higor.poc1.domain.model.Customer;
+import com.higor.poc1.domain.repository.CustomerRepository;
+import com.higor.poc1.domain.repository.CustomerRepositoryQueries;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class CustomerRepositoryImpl implements CustomerRepositoryQueries {
+
+    @PersistenceContext
+    private EntityManager manager;
+
+    @Autowired @Lazy
+    public CustomerRepository customerRepository;
+
+    @Override
+    public List<Customer> find(String name, String email, String registerNumber, String type, String phoneNumber) {
+        CriteriaBuilder builder = manager.getCriteriaBuilder();
+
+        CriteriaQuery<Customer> criteria = builder.createQuery(Customer.class);
+        Root<Customer> root = criteria.from(Customer.class);
+
+        var predicates = new ArrayList<Predicate>();
+
+        if (StringUtils.hasText(name)){
+            predicates.add(builder.like(root.get("name"), "%" + name + "%"));
+        }
+
+        if (StringUtils.hasText(email)){
+            predicates.add(builder.like(root.get("email"), "%" + email + "%"));
+        }
+
+        if (StringUtils.hasText(registerNumber)){
+            predicates.add(builder.like(root.get("registerNumber"), "%" + registerNumber + "%"));
+        }
+
+        if (StringUtils.hasText(type)){
+            predicates.add(builder.like(root.get("type"), "%" + type + "%"));
+        }
+
+        if (StringUtils.hasText(phoneNumber)){
+            predicates.add(builder.like(root.get("phoneNumber"), "%" + phoneNumber + "%"));
+        }
+
+        criteria.where(predicates.toArray(new Predicate[0]));
+
+        TypedQuery<Customer> query = manager.createQuery(criteria);
+
+        return query.getResultList();
+    }
+}


### PR DESCRIPTION
- Foram adicionados os filtros dinâmicos para todos os atributos de Customer e Address;
- É possível utilizar um, todos ou nenhum filtro;
- Ainda falta adicionar a pesquisa interna. Por exemplo, pesquisar o Customer pelo Bairro ou Cidade, que é um atributo do Address;
- Por enquanto, o controller está usando o endpoint "/search".